### PR TITLE
Bug: Unacceptable low performance on window Generate Invoice (manual)

### DIFF
--- a/org.adempiere.ui/src/org/compiere/apps/form/InvoiceGen.java
+++ b/org.adempiere.ui/src/org/compiere/apps/form/InvoiceGen.java
@@ -147,9 +147,12 @@ public class InvoiceGen extends GenForm
 		sql.append("AND EXISTS (SELECT * from C_InvoiceLine il inner join M_InOutLine iol ");
 		sql.append("on il.M_InOutLine_ID=iol.M_InOutLine_ID inner join C_Invoice i ");
 		sql.append("on i.C_Invoice_ID=il.C_Invoice_ID where i.DocStatus IN ('CO', 'CL') ");
-		sql.append("AND iol.M_InOutLine_ID IN ");
-		sql.append("(SELECT M_InOutLine_ID from M_RMALine rl where rl.M_RMA_ID=rma.M_RMA_ID ");
-		sql.append("AND rl.M_InOutLine_ID IS NOT NULL)) ");
+		//MPo, 23/07/2020
+		//sql.append("AND iol.M_InOutLine_ID IN ");
+		//sql.append("(SELECT M_InOutLine_ID from M_RMALine rl where rl.M_RMA_ID=rma.M_RMA_ID ");
+		//sql.append("AND rl.M_InOutLine_ID IS NOT NULL)) ");
+		sql.append("AND EXISTS (SELECT 1 FROM m_rmaline rl WHERE rl.m_rma_id = rma.m_rma_id AND iol.m_inoutline_id = rl.m_inoutline_id AND rl.m_inoutline_id IS NOT null)) ");
+		//
 		sql.append("AND rma.AD_Client_ID=?");
 
         if (m_AD_Org_ID != null)


### PR DESCRIPTION
Bug: Unacceptable low performance on window Generate Invoice (manual) with RMA 
Detail, when we are using, Generate invoice (Manual) window when select option invoice type = customer RMA, the system takes so long to query data and make the DB engine spike to 100% cause all system slowdown. 